### PR TITLE
Clarify reference to Coin-HSL software

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ in 2022 IEEE-RAS International Conference on Humanoid Robotics (Humanoids)
 ### Installation
 
 
-:warning: The repository depends on [HSL Mathematical Software Library](https://www.hsl.rl.ac.uk/), to correctly link the library please substitute [this](https://github.com/ami-iit/paper_sartore_2022_humanoids_ergonomic_design/blob/fc5083ca619d9c0dfe4e333fadad6d0f000c0dbf/Dockerfile#L26) line of the docker image with the absolute path to the `coinhsl.zip`
+:warning: The repository depends on [HSL for IPOPT (coinhsl)](https://www.hsl.rl.ac.uk/ipopt/), to correctly link the library please substitute [this](https://github.com/ami-iit/paper_sartore_2022_humanoids_ergonomic_design/blob/fc5083ca619d9c0dfe4e333fadad6d0f000c0dbf/Dockerfile#L26) line of the docker image with the absolute path to the `coinhsl.zip`. In particular for the paper experiments coinhsl 2019.05.21 have been used, but also later version should work fine. 
 
 ⚠️ This repository depends on [docker](https://docs.docker.com/)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ in 2022 IEEE-RAS International Conference on Humanoid Robotics (Humanoids)
 ### Installation
 
 
-:warning: The repository depends on [HSL for IPOPT (coinhsl)](https://www.hsl.rl.ac.uk/ipopt/), to correctly link the library please substitute [this](https://github.com/ami-iit/paper_sartore_2022_humanoids_ergonomic_design/blob/fc5083ca619d9c0dfe4e333fadad6d0f000c0dbf/Dockerfile#L26) line of the docker image with the absolute path to the `coinhsl.zip`. In particular for the paper experiments coinhsl 2019.05.21 have been used, but also later version should work fine. 
+:warning: The repository depends on [HSL for IPOPT (Coin-HSL)](https://www.hsl.rl.ac.uk/ipopt/), to correctly link the library please substitute [this](https://github.com/ami-iit/paper_sartore_2022_humanoids_ergonomic_design/blob/fc5083ca619d9c0dfe4e333fadad6d0f000c0dbf/Dockerfile#L26) line of the docker image with the absolute path to the `coinhsl.zip`. In particular for the paper experiments Coin-HSL 2019.05.21 have been used, but also later version should work fine. 
 
 ⚠️ This repository depends on [docker](https://docs.docker.com/)
 


### PR DESCRIPTION
If one access the https://www.hsl.rl.ac.uk website and tries to download some software, it is pointed to https://www.hsl.rl.ac.uk/catalogue/, that permit to download each solver separately. However, to compile the version of HSL's solvers that are compatible with IPOPT and https://github.com/coin-or-tools/ThirdParty-HSL, one needs to go to https://www.hsl.rl.ac.uk/ipopt/, that cannot be easily accessed from https://www.hsl.rl.ac.uk  .

For this reason, I think it is more clear if we direct the users to go directly to https://www.hsl.rl.ac.uk/ipopt/ .